### PR TITLE
Improvements/bug fixes for Cortex M0

### DIFF
--- a/src/EtherShield.c
+++ b/src/EtherShield.c
@@ -493,8 +493,10 @@ uint8_t allocateIPAddress(uint8_t *buf, uint16_t buffer_size, uint8_t *mymac, ui
           // Set the Router IP
           client_set_gwip(gwip);  // e.g internal IP of dsl router
 
+#ifdef DNS_client
           // Set the DNS server IP address if required, or use default
           dnslkup_set_dnsip( dnsip );
+#endif
 
         }
       }

--- a/src/dhcp.c
+++ b/src/dhcp.c
@@ -60,7 +60,7 @@ typedef struct dhcpData {
         // options
         // dont include as its variable size,
         // just tag onto end of structure
-} dhcpData;
+} __attribute__((packed)) dhcpData ;
 
 static uint8_t dhcptid_l=0; // a counter for transaction ID
 // src port high byte must be a a0 or higher:
@@ -178,9 +178,9 @@ void dhcp_send(uint8_t *buf, uint8_t requestType ) {
         dhcpPtr->hlen = 6;
         dhcpPtr->hops = 0;
         // 4-7 xid
-        dhcpPtr->xid = currentXid;
+        memcpy(&dhcpPtr->xid, &currentXid, sizeof(currentXid));
         // 8-9 secs
-        dhcpPtr->secs = currentSecs;
+        memcpy(&dhcpPtr->secs, &currentSecs, sizeof(currentSecs));
         // 16-19 yiaddr
         memset(dhcpPtr->yiaddr, 0, 4);
         // 28-43 chaddr(16)
@@ -250,7 +250,7 @@ uint8_t check_for_dhcp_answer(uint8_t *buf, uint16_t plen){
     // Map struct onto payload
     dhcpData *dhcpPtr = (dhcpData *)&buf[UDP_DATA_P];
     if (plen >= 70 && buf[UDP_SRC_PORT_L_P] == DHCP_SRC_PORT &&
-            dhcpPtr->op == DHCP_BOOTREPLY && dhcpPtr->xid == currentXid ) {
+            dhcpPtr->op == DHCP_BOOTREPLY && !memcmp(&dhcpPtr->xid, &currentXid, 4) ) {
         // Check for lease expiry
         // uint32_t currentSecs = millis();
         int optionIndex = UDP_DATA_P + sizeof( dhcpData ) + 4;

--- a/src/enc28j60.c
+++ b/src/enc28j60.c
@@ -382,7 +382,7 @@ void enc28j60DisableMulticast( void ) {
 uint8_t enc28j60linkup(void)
 {
         // bit 10 (= bit 3 in upper reg)
-	return(enc28j60PhyReadH(PHSTAT2) && 4);
+	return(enc28j60PhyReadH(PHSTAT2) & 4);
 }
 
 void enc28j60PacketSend(uint16_t len, uint8_t* packet)

--- a/src/enc28j60.c
+++ b/src/enc28j60.c
@@ -4,7 +4,7 @@ extern void Error_Handler(void);
 static uint8_t Enc28j60Bank;
 static uint16_t gNextPacketPtr;
 static uint8_t erxfcon;
-SPI_HandleTypeDef *hspi = NULL;
+static SPI_HandleTypeDef *hspi = NULL;
 
 #if 0
 void ENC28J60_hspi->Instance_Configuration(void)

--- a/src/enc28j60.c
+++ b/src/enc28j60.c
@@ -363,7 +363,7 @@ void enc28j60EnableBroadcast( void ) {
 }
 
 void enc28j60DisableBroadcast( void ) {
-	erxfcon &= (0xff ^ ERXFCON_BCEN);
+	erxfcon &= ~ERXFCON_BCEN;
 	enc28j60Write(ERXFCON, erxfcon);
 }
 
@@ -373,7 +373,7 @@ void enc28j60EnableMulticast( void ) {
 }
 
 void enc28j60DisableMulticast( void ) {
-	erxfcon &= (0xff ^ ERXFCON_MCEN);
+	erxfcon &= ~ERXFCON_MCEN;
 	enc28j60Write(ERXFCON, erxfcon);
 }
 


### PR DESCRIPTION
Cortex M0 does not do unaligned access, use memcpy().
Fix some typos.
Hide SPI handle (does not need to be global)
